### PR TITLE
Add Github Action CI

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -1,0 +1,33 @@
+name: Build Summer Growth
+on:
+  push:
+    paths:
+      - "Working Files/**"
+  pull_request:
+    paths:
+      - "Working Files/**"
+  workflow_dispatch:
+
+
+jobs:
+  build:
+    # Windows 10 with latest image
+    runs-on: windows-latest
+    name: build
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Build Summer Growth
+        shell: bash
+        run: |
+          cd "Working Files"
+          ./tweego.exe SummerGrowthDevelopment.twee > SummerGrowthDevelopment.html
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: SummerGrowthDevelopment
+          path: "${{github.workspace}}/Working Files/SummerGrowthDevelopment.html"
+          retention-days: 90
+

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -2,9 +2,11 @@ name: Build Summer Growth
 on:
   push:
     paths:
+      - ".github/**"
       - "Working Files/**"
   pull_request:
     paths:
+      - ".github/**"
       - "Working Files/**"
   workflow_dispatch:
 


### PR DESCRIPTION
Basic Github Actions workflow that just builds and uploads the html artifact to the Action's job page whenever somebody pushes a commit or submits a PR.